### PR TITLE
Fix YamlDotNet Extension add-on (OSK-3)

### DIFF
--- a/src/OSK.Serialization.Yaml.YamlDotNet/OSK.Serialization.Yaml.YamlDotNet.csproj
+++ b/src/OSK.Serialization.Yaml.YamlDotNet/OSK.Serialization.Yaml.YamlDotNet.csproj
@@ -10,6 +10,10 @@
 		<Title>OSK.Serialization.Yaml.YamlDotNet</Title>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />

--- a/src/OSK.Serialization.Yaml.YamlDotNet/ServiceCollectionExtensions.cs
+++ b/src/OSK.Serialization.Yaml.YamlDotNet/ServiceCollectionExtensions.cs
@@ -13,7 +13,7 @@ namespace OSK.Serialization.Yaml.YamlDotNet
     public static class ServiceCollectionExtensions
     {
         public static IServiceCollection AddYamlDotNetSerialization(this IServiceCollection services)
-            => services.AddYamlSerialization(o =>
+            => services.AddYamlDotNetSerialization(o =>
             {
                 var options = YamlDotNetSerializer.DefaultOptions;
                 o.SerializationNamingConvention = options.SerializationNamingConvention;
@@ -25,7 +25,7 @@ namespace OSK.Serialization.Yaml.YamlDotNet
                 o.CustomTypeConverters = new List<IYamlTypeConverter>();
             });
 
-        public static IServiceCollection AddYamlSerialization(this IServiceCollection services,
+        public static IServiceCollection AddYamlDotNetSerialization(this IServiceCollection services,
             Action<YamlDotNetSerializationOptions> options)
         {
             services.Configure(options);


### PR DESCRIPTION
Motivation
----
The current YamlDotNet extension for configuring options is misnamed

Modifications
----
* Renamed current extension to be consistent with outher extensions
* Added MIT license for Nuget

Result
-----
Extension is named as expected and MIT license is shown on Nuget

Fixes #3